### PR TITLE
fix kong dockerfile

### DIFF
--- a/cmds/kong/bootstrap/Dockerfile
+++ b/cmds/kong/bootstrap/Dockerfile
@@ -1,2 +1,2 @@
 FROM kong/deck
-COPY deck.yml /kong.yml
+COPY deck.yml /kong.yaml


### PR DESCRIPTION
Fix kong dockerfile 

- In lastest [PR](https://github.com/dp-icea/dss/pull/6), dockerfile was changed to use .yml extension but kong state file must be in JSON or YAML format as stated in [documentation](https://docs.konghq.com/deck/latest/terminology/).

Which caused the following error:

![Captura de tela de 2024-08-05 15-56-30](https://github.com/user-attachments/assets/214816dd-34a3-4394-aa01-49e3b2934e8b)
